### PR TITLE
Add babel-register under -b flag for ES6 tasks

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -6,18 +6,22 @@ import routine from 'promise-routine';
 import { join } from 'path';
 
 const args = process.argv.slice(2);
-const sets = list(args);
-const opts = minimist(args);
+const opts = minimist(args, { boolean: true });
+const sets = list(opts._);
 const tasks = [];
 
 // Setup CLI for routine
 if (sets.length > 1 || opts.i) {
   sets.forEach(set => {
-    const mic = minimist(set.slice(1));
-    tasks.push([set[0], mic, mic._]);
+    const mic = minimist(set);
+    tasks.push([set[0], mic, mic._.slice(1)]);
   });
 } else {
   sets[0].forEach(task => tasks.push([task, {}, {}]));
+}
+
+if (opts.b || opts.babel) {
+  require(require.resolve('babel-register'));
 }
 
 // Run the config, which defines the tasks.


### PR DESCRIPTION
If your project has `babel-register`, you can use the `-b` flag to have it interpret your `osia.js`.
```shell
$ osia -b task
```
Fixes #5 