### PR TITLE
Add new system

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
   },
   "dependencies": {
     "chalk": "^1.1.1",
-    "cli-list": "^0.1.6",
     "minimist": "^1.2.0",
     "promise-routine": "^0.2.0",
-    "vinyl-read": "^1.0.0"
+    "vinyl-read": "^1.0.0",
+    "vinyl-write": "^0.1.1"
   }
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,12 +1,10 @@
 #!/usr/bin/env node
 import osia from '.';
 import minimist from 'minimist';
-import list from 'cli-list';
-import routine from 'promise-routine';
 import { join } from 'path';
 
-const args = process.argv.slice(2);
-const opts = minimist(args, {
+// Create CLI
+const opts = minimist(process.argv.slice(2), {
   boolean: true,
   default: {
     version: false,
@@ -21,26 +19,18 @@ const opts = minimist(args, {
     color: 'c',
   },
 });
-const sets = list(opts._);
-const tasks = [];
 
-if (sets.length > 1 || opts.i) {
-  sets.forEach(set => {
-    const mic = minimist(set);
-    tasks.push([set[0], mic, mic._.slice(1)]);
-  });
-} else {
-  sets[0].forEach(task => tasks.push([task, {}, {}]));
-}
+// Tasks, use "default" if none.
+const tasks = opts._;
+if (!tasks.length) tasks.push('default');
 
-if (opts.babel) {
-  require(require.resolve('babel-register'));
-}
+// Enable babel
+if (opts.babel) require(require.resolve('babel-register'));
 
-if (opts.version) {
-  osia.log(`CLI Version v${require('../package.json').version}`);
-}
+// Show version
+if (opts.version) osia.log(`CLI Version v${require('../package.json').version}`);
 
+// Help page
 if (opts.help) {
   console.log(`
   Usage:
@@ -52,8 +42,9 @@ if (opts.help) {
   `);
 }
 
+// Propagate color on/off in system.
 osia.meta.color = opts.color;
 
+// Start Osia
 require(join(process.cwd(), 'osia.js'));
-
-routine((...o) => osia.run(...o), ...tasks);
+osia.start(tasks);

--- a/src/cli.js
+++ b/src/cli.js
@@ -28,18 +28,24 @@ if (!tasks.length) tasks.push('default');
 if (opts.babel) require(require.resolve('babel-register'));
 
 // Show version
-if (opts.version) osia.log(`CLI Version v${require('../package.json').version}`);
+if (opts.version) {
+  console.log(`v${require('../package.json').version}`);
+  process.exit(0);
+}
 
 // Help page
 if (opts.help) {
   console.log(`
   Usage:
     osia [...tasks]
+
   Options:
-    -h --help     Show this message
-    -v --version  Show version
-    -b --babel    Add babel support
+    --help, -h     Show this page.
+    --version, -v  Show Osia version.
+    --babel, -b    Use babel-register in task file.
+    --no-color     Disable colorful logging
   `);
+  process.exit(0);
 }
 
 // Propagate color on/off in system.

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,3 @@
+// Initialize the Osia system.
 import System from './system';
-import Task from './task';
-
-const osia = new System();
-
-osia.System = System;
-osia.Task = Task;
-
-export default osia;
+export default (new System());

--- a/src/message.js
+++ b/src/message.js
@@ -1,0 +1,11 @@
+import { blue, green, grey } from 'chalk';
+
+export default function message(name, text, extra = '', color = true) {
+  if (color) {
+    // Relog in color
+    return message(blue(name), green(text), grey(extra), false);
+  }
+
+  // Standard Osia log format.
+  return `[${name}] ${text} ${extra}`;
+}

--- a/src/system.js
+++ b/src/system.js
@@ -1,58 +1,105 @@
 import read from 'vinyl-read';
+import write from 'vinyl-write';
 import Task from './task';
 import path from 'path';
-import plugin from './plugin';
-import fs from 'fs';
+import routine from 'promise-routine';
+import timer from './timer';
+import m from './message';
 
 class System {
-  constructor(tasks = {}, name = 'osia', meta = {}) {
+  constructor(tasks = {}, meta = { name: 'osia' }) {
     this.tasks = tasks;
-    this.name = name;
     this.meta = meta;
 
-    this.meta.startTime = process.hrtime();
+    // System naming conviention
+    if (this.meta.name) this.meta.name = `~${this.meta.name}`;
   }
 
   task(...args) {
-    let route = null;
-    let deps = null;
-    let fn = function fn() {};
+    let name = null;
+    let deps = [];
+    let fn = () => {};
 
-    if (args.length === 2) [route, fn] = args;
-    else if (args.length === 3) [route, deps, fn] = args;
+    // Flexible arguments.
+    if (args.length === 2) [name, fn] = args;
+    else if (args.length === 3) [name, deps, fn] = args;
 
-    this.tasks[route] = new Task(route, fn, {
-      color: this.meta.color,
-      systemStartTime: this.meta.startTime,
+    // Function-less tasks (point to other tasks).
+    if (Array.isArray(fn)) {
+      const de = fn;
+      fn = () => Promise.all(de.map(d => this._startAfterDeps(d)));
+    }
+
+    // Create task
+    this.tasks[name] = new Task(fn, {
+      name,
       deps,
+      color: this.meta.color,
     });
   }
 
-  run(route = 'default', opts, args) {
-    return this.tasks[route].start(opts, args);
-  }
+  start(tasks = ['default']) {
+    // Setup tasks and timer
+    if (typeof tasks === 'string') tasks = [tasks];
+    const results = timer(this);
 
-  log(message) {
-    console.log(`[${this.name}] ${message}`);
-  }
-
-  error(message) {
-    console.log(`[${this.name}] ${message}`);
-    throw new Error(message, this.name);
+    // Handle ending
+    return routine(this._startAfterDeps.bind(this), ...tasks).then(x => {
+      results();
+      return x;
+    });
   }
 
   open(files) {
+    // Read file, creating promise pipeline
     return read(files);
   }
 
   save(base) {
-    return plugin((file, resolve, reject) => {
+    // Create file-routine to change directory and write.
+    return files => routine(file => {
       file.dirname = path.resolve(base);
-      fs.writeFile(file.path, file.contents,
-        (err) => (err ? reject(err) : resolve(file))
-      );
-    });
+      return write(file);
+    }, ...files);
   }
+
+  _startAfterDeps(taskName) {
+    // Get task and setup vars
+    const task = this.tasks[taskName];
+    const depTasks = [];
+    let dep = null;
+
+    // Make sure task is valid
+    if (typeof task === 'undefined') {
+      console.log(m(`${this.meta.name}`, `Task '${taskName}' not found!`));
+      return Promise.resolve({ name: taskName, message: 'not found' });
+    }
+
+    // Loop through task deps, decide whether they need to be started/pended on.
+    for (const depName of task.meta.deps) {
+      dep = this.tasks[depName];
+
+      switch (dep.state) {
+        case 'running':
+          depTasks.push(dep.process);
+          break;
+        case 'ran':
+          continue;
+        default:
+          depTasks.push(this._startAfterDeps(depName));
+      }
+    }
+
+    // Wait on deps and start.
+    return Promise.all(depTasks).then(() => (
+      task.state === 'off'
+      ? task.start()
+      : task.process
+    ));
+  }
+
+  // Small system naming function.
+  name(x) { this.meta.name = `~${x}`; }
 }
 
 export default System;

--- a/src/timer.js
+++ b/src/timer.js
@@ -1,0 +1,10 @@
+import m from './message';
+
+export default function timer(item) {
+  console.log(m(`${item.meta.name}`, 'Starting', '', item.meta.color));
+  const time = process.hrtime();
+  return () => {
+    const [, nano] = process.hrtime(time);
+    console.log(m(`${item.meta.name}`, 'Finished', `(in ${nano / 1000000}ms)`, item.meta.color));
+  };
+}


### PR DESCRIPTION
Adds/Fixes:
 - New CLI: Minimalistic and colorful.
 - Task dependencies: `osia.task(name, deps, fn)`
 - `timer(obj)`: Time and print to log.
 - `message(name, message, [extra, color])`: Generate formatted and colorful log messages.
 - `System#_startAfterDeps`: Dependency-aware task running in system.
 - Alias/pointer tasks: `osia.task('foo', [ 'bar', 'baz' ])`
 - Commented code.

Removes:
 - Task options and arguments
 - Quick accessors (i.e. `osia.System`, `osia.Task`, etc.)
 - Logging from `System#log` and `Task#log` (use `message()` instead)